### PR TITLE
fix(ButtonTypes): default button with correct text

### DIFF
--- a/_components/button/ButtonTypes.js
+++ b/_components/button/ButtonTypes.js
@@ -4,7 +4,7 @@ export default function ButtonTypes() {
   return (
     <>
       <Button type="primary">Primary Button</Button>
-      <Button type="default">Primary Button</Button>
+      <Button type="default">Default Button</Button>
       <Button type="dashed">Dashed Button</Button>
       <Button type="outline">Outline Button</Button>
       <Button type="text">Text Button</Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The default button was indicating that it was a primary button

## What is the new behavior?

default button with correct text

## Additional context

https://ui.supabase.com/components/button
