### PR TITLE
Correct badge import statement

### DIFF
--- a/_components/badge/index.mdx
+++ b/_components/badge/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Tabs } from '@supabase/ui'
+@import { Badge } from '@supabase/ui'
 ```
 
 ## Basic


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

<img width="690" alt="image" src="https://user-images.githubusercontent.com/15057364/114084879-824aef80-9865-11eb-9c37-6d332bb17bc3.png">
Badge Documentation says to import Tabs