### PR TITLE
Added size example to the code

### DIFF
--- a/_components/badge/BadgeBasic.js
+++ b/_components/badge/BadgeBasic.js
@@ -11,6 +11,9 @@ export default function BadgeBasic() {
       <Badge color="purple">purple</Badge>
       <Badge color="red">red</Badge>
       <Badge color="yellow">yellow</Badge>
+    
+      <Badge size="large">large</Badge>
+      <Badge size="small">small</Badge>
     </>
   );
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Does not include size in docs

## What is the new behavior?

Includes size in docs

## Additional context

Previously the docs did not specify `size` in the Badge section, I've add it to the docs.
