### PR TITLE
fix(page-slug): handle scroll to top when page change

### DIFF
--- a/pages/components/[slug].tsx
+++ b/pages/components/[slug].tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import fs from 'fs'
 import path from 'path'
 
@@ -37,6 +38,13 @@ export default function Home({ source, frontmatter, toc }: any) {
       <ReactMarkdown plugins={[gfm]}>{toc.content}</ReactMarkdown>
     </div>
   )
+
+  useEffect(() => {
+    if (typeof document !== undefined && document) {
+      const container = document.querySelector('main')
+      container?.scroll(0, 0)
+    }
+  })
 
   return (
     <DefaultLayout>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Handle scroll when client change page.

## What is the current behavior?

Scroll don't move up when users change page.
Issue #5

## What is the new behavior?

When client change page scroll will move to top.

https://user-images.githubusercontent.com/13243693/127742144-66a4eb3c-cf80-4e7f-9037-9e15ff2e092a.mov

## Additional context

This change is just a fix, that behavior should be default behavior, but actual layout of the page break this behavior.