### PR TITLE
chore: remove @ symbol from import commands

### DIFF
--- a/_components/alert/index.mdx
+++ b/_components/alert/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Alert } from '@supabase/ui'
+import { Alert } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/badge/index.mdx
+++ b/_components/badge/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Badge } from '@supabase/ui'
+import { Badge } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/button/index.mdx
+++ b/_components/button/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Button } from '@supabase/ui'
+import { Button } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/card/index.mdx
+++ b/_components/card/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Card } from '@supabase/ui'
+import { Card } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/checkbox/index.mdx
+++ b/_components/checkbox/index.mdx
@@ -14,7 +14,7 @@ img: "/images/button.svg"
 Import the component
 
 ```js
-@import { Checkbox } from '@supabase/ui'
+import { Checkbox } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/dropdown/index.mdx
+++ b/_components/dropdown/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Dropdown } from '@supabase/ui'
+import { Dropdown } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/input/index.mdx
+++ b/_components/input/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Input } from '@supabase/ui'
+import { Input } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/inputnumber/index.mdx
+++ b/_components/inputnumber/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { InputNumber } from '@supabase/ui'
+import { InputNumber } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/menu/index.mdx
+++ b/_components/menu/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Menu } from '@supabase/ui'
+import { Menu } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/modal/index.mdx
+++ b/_components/modal/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Modal } from '@supabase/ui'
+import { Modal } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/radio/index.mdx
+++ b/_components/radio/index.mdx
@@ -14,7 +14,7 @@ img: "/images/button.svg"
 Import the component
 
 ```js
-@import { Radio } from '@supabase/ui'
+import { Radio } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/select/index.mdx
+++ b/_components/select/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Input } from '@supabase/ui'
+import { Input } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/sidepanel/index.mdx
+++ b/_components/sidepanel/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Modal } from '@supabase/ui'
+import { Modal } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/tabs/index.mdx
+++ b/_components/tabs/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Tabs } from '@supabase/ui'
+import { Tabs } from '@supabase/ui'
 ```
 
 ## Basic

--- a/_components/typography/index.mdx
+++ b/_components/typography/index.mdx
@@ -17,14 +17,14 @@ npm install @supabase/ui
 Import the component
 
 ```js
-@import { Typography } from '@supabase/ui'
+import { Typography } from '@supabase/ui'
 ```
 
 This component contains sub components which might be easier to use in variables.
 Alternative import method can be to do the following.
 
 ```js
-@import { Typography } from '@supabase/ui'
+import { Typography } from '@supabase/ui'
 
 const { Title, Text, Link } = Typography;
 


### PR DESCRIPTION
![typo](https://media1.giphy.com/media/xT0xeAPJVuEtQZwm8E/giphy.gif)

## What kind of change does this PR introduce?

docs: fixes a typo

## What is the current behavior?

A few of the `import` statements have an `@` symbol before them:

<img width="670" alt="Screen Shot 2021-09-08 at 3 38 38 pm" src="https://user-images.githubusercontent.com/13792200/132452605-34e9d0cd-9d1c-4386-8c40-73fe03e4e301.png">
