### PR TITLE
chore: fix typo on select component page

### DIFF
--- a/_components/select/index.mdx
+++ b/_components/select/index.mdx
@@ -17,7 +17,7 @@ npm install @supabase/ui
 Import the component
 
 ```js
-import { Input } from '@supabase/ui'
+import { Select } from '@supabase/ui'
 ```
 
 ## Basic


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update!

## What is the current behavior?

Currently on Select component page it says:
```
import { Input } from '@supabase/ui'
```

## What is the new behavior?

I updated it to say:
```
import { Select } from '@supabase/ui'
```

