### PR TITLE
fix for supabase-ui-web fix non clickable menu items

### DIFF
--- a/components/DefaultLayout.tsx
+++ b/components/DefaultLayout.tsx
@@ -86,8 +86,8 @@ function DefaultLayout(props: any) {
             <Link href="/">
               <Menu.Item>Introduction</Menu.Item>
             </Link>
-            <Menu.Item>Dark mode setup (coming soon)</Menu.Item>
-            <Menu.Item>Theming (coming soon)</Menu.Item>
+            <Menu.Item style={{pointerEvents: 'none' }}>Dark mode setup (coming soon)</Menu.Item>
+            <Menu.Item style={{pointerEvents: 'none' }}>Theming (coming soon)</Menu.Item>
             <Link href="/license">
               <Menu.Item>License</Menu.Item>
             </Link>


### PR DESCRIPTION
Closes #34 

This is a fix to make coming soon menu items on the ui.supabase.com site non clickable as they do not link to anything at the moment

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
