### PR TITLE
Fix Icons-route

### DIFF
--- a/components/ComponentIndex.tsx
+++ b/components/ComponentIndex.tsx
@@ -13,10 +13,12 @@ import ButtonBlockRaw from '!!raw-loader!./../_components/button/ButtonBlock'
 import IconBasic from '../_components/icon/IconBasic'
 import IconSize from '../_components/icon/IconSize'
 import IconStroke from '../_components/icon/IconStroke'
+import { IconMail } from '@supabase/ui' // We need to import the icon here aswell, otherwise it will not work in the components above.
 
 import IconBasicRaw from '!!raw-loader!./../_components/icon/IconBasic'
 import IconSizeRaw from '!!raw-loader!./../_components/icon/IconSize'
 import IconStrokeRaw from '!!raw-loader!./../_components/icon/IconStroke'
+import { IconMail as IconMailRaw } from '@supabase/ui' // We need to import the icon here aswell, otherwise it will not work in the components above.
 
 import AuthBasic from '../_components/auth/AuthBasic'
 import AuthSocialProviders from '../_components/auth/AuthSocialProviders'
@@ -368,10 +370,12 @@ RawComponents['BadgeDot'] = BadgeDotRaw
 Components['IconBasic'] = IconBasic
 Components['IconSize'] = IconSize
 Components['IconStroke'] = IconStroke
+Components['IconMail'] = IconMail
 
 RawComponents['IconBasic'] = IconBasicRaw
 RawComponents['IconSize'] = IconSizeRaw
 RawComponents['IconStroke'] = IconStrokeRaw
+RawComponents['IconMail'] = IconMailRaw
 
 // Card
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the Icons-route as described in #45

For some reason, the icons is not loaded when imported inside a component that is is loaded via an `.mdx`-file.
I added the icon to `ComponentIndex.tsx` and now it seems to work. If I remove the imports from the `IconBasic`, `IconSize` and `IconStroke`-components, the issue appears again.

If anyone has more knowledge with using components in MDX, please feel free to comment.
But for now, this fixes it. :) But should probably look for a better solution, if there's plans for an icon library and filter.

## What is the current behavior?

Error is shown on the page, because `IconMail`-icon is not being imported correctly.

![image](https://user-images.githubusercontent.com/12418495/150611503-06919bc0-3e9d-4fe8-a1c5-e311ca45ad5a.png)


## What is the new behavior?

The Icons-page is successfully loaded and icons shown correctly.

![image](https://user-images.githubusercontent.com/12418495/150611309-d98da34c-d556-42d2-9005-46da1e107004.png)


## Additional context

Fixes #45 
