### PR TITLE
Follow system dark mode preference

### DIFF
--- a/components/DefaultLayout.tsx
+++ b/components/DefaultLayout.tsx
@@ -31,7 +31,7 @@ function DefaultLayout(props: any) {
     const prefersColorScheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches).toString()
     if (previousVisit !== prefersColorScheme) {
       previousVisit = prefersColorScheme
-      localStorage.setItem('supabaseDarkMode', (prefersColorScheme).toString())
+      localStorage.setItem('supabaseDarkMode', prefersColorScheme)
     }
     const isDarkMode = previousVisit == null ? darkMode : previousVisit == 'true'
     setDarkMode(isDarkMode)

--- a/components/DefaultLayout.tsx
+++ b/components/DefaultLayout.tsx
@@ -28,6 +28,11 @@ function DefaultLayout(props: any) {
 
   useEffect(() => {
     const previousVisit = localStorage.getItem('supabaseDarkMode')
+    const prefersColorScheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches).toString()
+    if (previousVisit !== prefersColorScheme) {
+      previousVisit = prefersColorScheme
+      localStorage.setItem('supabaseDarkMode', (prefersColorScheme).toString())
+    }
     const isDarkMode = previousVisit == null ? darkMode : previousVisit == 'true'
     setDarkMode(isDarkMode)
     document.documentElement.className = isDarkMode ? 'dark' : ''

--- a/components/DefaultLayout.tsx
+++ b/components/DefaultLayout.tsx
@@ -29,11 +29,8 @@ function DefaultLayout(props: any) {
   useEffect(() => {
     const previousVisit = localStorage.getItem('supabaseDarkMode')
     const prefersColorScheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches).toString()
-    if (previousVisit !== prefersColorScheme) {
-      previousVisit = prefersColorScheme
-      localStorage.setItem('supabaseDarkMode', prefersColorScheme)
-    }
-    const isDarkMode = previousVisit == null ? darkMode : previousVisit == 'true'
+    if (previousVisit !== prefersColorScheme) localStorage.setItem('supabaseDarkMode', prefersColorScheme)
+    const isDarkMode = prefersColorScheme == null ? darkMode : prefersColorScheme == 'true'
     setDarkMode(isDarkMode)
     document.documentElement.className = isDarkMode ? 'dark' : ''
   }, [])


### PR DESCRIPTION
Use the prefers-color-scheme css media feature to update supabaseDarkMode local storage key.

## What kind of change does this PR introduce?

feature

## What is the current behavior?

the dark mode toggle does not follow the system theme preference

## What is the new behavior?

the `supabaseDarkMode` localStorage key will be updated based on system theme preference

## Additional context

[`prefers-color-scheme` mdn documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)