### PR TITLE
chore: update the copyright year in LICENSE on the site

### DIFF
--- a/_posts/License.mdx
+++ b/_posts/License.mdx
@@ -2,7 +2,7 @@
 title: MIT License
 ---
 
-Copyright (c) 2021 Supabase
+Copyright (c) 2021 - present Supabase
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The copyright year mentioned in the LICENSE on the site seems to be outdated.

## What is the new behavior?

Updated the copyright year with `present` so that no need to update it every time 
